### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ using pip:
 If you've never used `nltk` before, you'll need to install the wordnet module.
 
     python -c "import nltk; nltk.download('wordnet')"
+    
+On OS X, you may need to install `coreutils` and `gnu-sed` for the script `download_data.sh` to run correctly. These can be installed using brew:
+
+    brew install coreutils gnu-sed
+
+After installation, you will either need to modify `download_data.sh` to run `gsort` and `gsed` instead of `sort` and `sed`, or alternatively add a "gnubin" directory to your PATH from your bashrc:
+
+    PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+
+For more information, see `brew info coreutils` or `brew info gnu-sed`.
 
 ## Evaluating your own model
 

--- a/download_data.sh
+++ b/download_data.sh
@@ -128,7 +128,7 @@ function download_wbless () {
 function download_eval () {
     echo -e 'word1\tword2\tlabel\trelation\tfold'
     curl $CURL_OPTIONS "$VERED_REPO_URL/EVALution.val" "$VERED_REPO_URL/EVALution.test" | \
-        sed 's/-[jvn]\t/\t/g' | sort | uniq | \
+        sort | uniq | sed 's/-[jvn]\t/\t/g' | \
         deterministic_shuffle | \
         awk '{if (NR < 737) {print $0 "\tval"} else {print $0 "\ttest"}}'
 }
@@ -154,7 +154,7 @@ fi
 if [ ! -x "$(command -v openssl)" ]
 then
     warning "This script requires the 'openssl' tool. Please run"
-    warning "  brew install openssl"
+    warning "  brew install unrar"
     warning "or whatever your system's equivalent is."
     exit 1
 fi

--- a/download_data.sh
+++ b/download_data.sh
@@ -128,7 +128,7 @@ function download_wbless () {
 function download_eval () {
     echo -e 'word1\tword2\tlabel\trelation\tfold'
     curl $CURL_OPTIONS "$VERED_REPO_URL/EVALution.val" "$VERED_REPO_URL/EVALution.test" | \
-        sort | uniq | sed 's/-[jvn]\t/\t/g' | \
+        sed 's/-[jvn]\t/\t/g' | sort | uniq | \
         deterministic_shuffle | \
         awk '{if (NR < 737) {print $0 "\tval"} else {print $0 "\ttest"}}'
 }

--- a/download_data.sh
+++ b/download_data.sh
@@ -154,7 +154,7 @@ fi
 if [ ! -x "$(command -v openssl)" ]
 then
     warning "This script requires the 'openssl' tool. Please run"
-    warning "  brew install unrar"
+    warning "  brew install openssl"
     warning "or whatever your system's equivalent is."
     exit 1
 fi


### PR DESCRIPTION
I believe the ordering of stripping the postags  `sed 's/-[jvn]\t/\t/g'` should be before sorting and piping into `uniq`, since there are lines in this dataset that are equal apart from the postags. For example:
abstract-j      concrete-j      False   antonym
abstract-n      concrete-n      False   antonym
abstract-v      concrete-v      False   antonym

As it is, the code includes all of these in the processed dataset as:

abstract      concrete      False   antonym
abstract      concrete      False   antonym
abstract      concrete      False   antonym

and also clumps them together, since sort --random-sort keeps identical lines together. 


